### PR TITLE
AWS keys are optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ gulp.task('deploy', function() {
         timestamp: true, // optional: If set to false, the zip will not have a timestamp
         waitForDeploy: true, // optional: if set to false the task will end as soon as it is deploying
         amazon: {
-            accessKeyId: "< your access key (fyi, the 'short' one) >",
-            secretAccessKey: "< your secret access key (fyi, the 'long' one) >",
+            accessKeyId: "< your access key (fyi, the 'short' one) >" //optional,
+            secretAccessKey: "< your secret access key (fyi, the 'long' one) >" //optional,
             region: 'eu-west-1',
             bucket: 'elasticbeanstalk-apps',
             applicationName: 'MyApplication',
@@ -31,7 +31,7 @@ gulp.task('deploy', function() {
 
 The code above would work as follows
 * Take the files sepcified by `gulp.src` and zip them on a file named `{ version }-{ timestamp }.zip` (i.e: `1.0.0-2016.04.08_13.26.32.zip`)
-* Check amazon credentials (`accessKeyId`, `secretAccessKey`)
+* Check amazon credentials (`accessKeyId`, `secretAccessKey`). If not provided in the `amazon` obejct, default values will be used from AWS CLI configuration.
 * Try to create the bucket specified by `amazon.bucket`. If you already own it, continues; otherwise fails
 * Uploads the ziped files to the bucket on the path `{{ name }}/{{ filename }}` (i.e: `my-application/1.0.0-2016.04.08_13.26.32.zip`)
 * Creates a new version on the Application specified by `applicationName` with VersionLabel `{ version }-{ timestamp }` (i.e: `1.0.0-2016.04.08_13.26.32`)

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,10 +58,13 @@ var wait4deploy = function(bean, envName) {
         opts.versionLabel += '-' + moment().format('YYYY.MM.DD_HH.mm.ss')
     opts.filename = opts.versionLabel + '.zip'
 
-    AWS.config.credentials = new AWS.Credentials({
-        accessKeyId: opts.amazon.accessKeyId,
-        secretAccessKey: opts.amazon.secretAccessKey
-    })
+    //if keys are provided, create new credentials, otherwise defaults will be used
+    if( opts.amazon.accessKeyId && opts.amazon.secretAccessKey ){
+        AWS.config.credentials = new AWS.Credentials({
+            accessKeyId: opts.amazon.accessKeyId,
+            secretAccessKey: opts.amazon.secretAccessKey
+        })
+    }
 
     var iam = new AWS.IAM()
     var bean = new AWS.ElasticBeanstalk({


### PR DESCRIPTION
This PR only creates the `AWS.config` credentials if the key and secret are included in the `amazon` object. If they are not present, the settings from the AWS CLI will be used (typically the "default" profile).

This avoids having keys in the source, which is a bad practice.
