### PR TITLE
require fewer permissions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,6 +88,18 @@ var wait4deploy = function(bean, envName) {
         var upload = bucket.upload({ Body: file.contents })
         var send = Promise.promisify(upload.send, { context: upload })
         return send()
+        .catch(function(err){
+          if (err.code == 'NoSuchBucket'){
+            return bucket.createBucketAsync().then(function(){ return send })
+          }
+          return Promise.reject(err);
+        })
+        .catch(function(err){
+          if(err.code == 'AccessDenied'){
+            return Promise.reject(new Error(err.code + " when creating bucket: " + bucket.config.params.Bucket))
+          }
+          return Promise.reject(err)
+        })
         .then(function() {
             return bean.createApplicationVersionAsync({
                 ApplicationName: opts.amazon.applicationName,

--- a/lib/index.js
+++ b/lib/index.js
@@ -85,19 +85,9 @@ var wait4deploy = function(bean, envName) {
     var outStream = inStream
     .pipe(through(function (file, enc, cb) {
 
-        iam.getUserAsync()
-        .then(function() {
-            return bucket.createBucketAsync()
-        })
-        .catch(function(err) {
-            if (err.code != 'BucketAlreadyOwnedByYou')
-                throw err
-        })
-        .then(function() {
-            var upload = bucket.upload({ Body: file.contents })
-            var send = Promise.promisify(upload.send, { context: upload })
-            return send()
-        })
+        var upload = bucket.upload({ Body: file.contents })
+        var send = Promise.promisify(upload.send, { context: upload })
+        return send()
         .then(function() {
             return bean.createApplicationVersionAsync({
                 ApplicationName: opts.amazon.applicationName,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-elasticbeanstalk-deploy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Gulp plugin for deploying into Amazon Elastic Beanstalk instance",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
first off, thanks so much this plugin has been working great for our deployments.  

For this change, we were working to reduce the number of IAM permissions required by the user. We have a strict policy and needed to remove the `iam:GetUser` and `s3:CreateBucket` permissions. 

If you have thoughts on how to make those calls optional, let me know and I'll create a better PR for you. 
