### PR TITLE
Added SignatureVersion 4 to support other regions

### DIFF
--- a/src/aws.js
+++ b/src/aws.js
@@ -23,7 +23,8 @@ export class S3File {
             params: {
                 Bucket: bucket,
                 Key: path
-            }
+            },
+			signatureVersion: 'v4'            
         })
 
         /**


### PR DESCRIPTION
Since only the regions added before 30th January 2014 support Version 2, it would not be possible to use this plugin with newer regions (i.e. eu-central-1). Source: http://stackoverflow.com/a/26538266

To add support for Version 4 only one parameter for the S3Bucket is needed. Source: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version