### PR TITLE
add support for passing an AWS.Credentials object

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ gulp.task('deploy', function() {
                 accessKeyId: "< your access key (fyi, the 'short' one) >", // optional
                 secretAccessKey: "< your secret access key (fyi, the 'long' one) >", // optional
             }
-            signatureVersion: "v4", // optional
+            config: { // optional
+                signatureVersion: "v4",
+            }
             region: 'eu-west-1',
             bucket: 'elasticbeanstalk-apps',
             applicationName: 'MyApplication',

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ gulp.task('deploy', function() {
         timestamp: true, // optional: If set to false, the zip will not have a timestamp
         waitForDeploy: true, // optional: if set to false the task will end as soon as it starts deploying
         amazon: {
-            accessKeyId: "< your access key (fyi, the 'short' one) >", // optional
-            secretAccessKey: "< your secret access key (fyi, the 'long' one) >", // optional
+            credentials: {
+                accessKeyId: "< your access key (fyi, the 'short' one) >", // optional
+                secretAccessKey: "< your secret access key (fyi, the 'long' one) >", // optional
+            }
             signatureVersion: "v4", // optional
             region: 'eu-west-1',
             bucket: 'elasticbeanstalk-apps',
@@ -38,7 +40,11 @@ gulp.task('deploy', function() {
 
 The code above would work as follows
 * Take the files sepcified by `gulp.src` and zip them on a file named `{ version }-{ timestamp }.zip` (i.e: `1.0.0-2016.04.08_13.26.32.zip`)
-* If amazon credentials (`accessKeyId`, `secretAccessKey`) are provided in the `amazon` object, set them on the `AWS.config.credentials`. If not provided, the default values from AWS CLI configuration will be used.
+* There are multiple ways to provide AWS credentials:
+  1. as an [AWS.Credentials](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Credentials.html) object or an object of any inheriting class
+  2. as an object holding parameters to AWS.Credentials or any of the following inheriting classes: [AWS.CognitoIdentityCredentials](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CognitoIdentityCredentials.html), [AWS.SharedIniFileCredentials](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SharedIniFileCredentials.html), [AWS.SAMLCredentials](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SAMLCredentials.html), [AWS.TemporaryCredentials](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/TemporaryCredentials.html), which gulp-elasticbeanstalk-deploy will then try to autodetect.
+  3. as a string either holding the path to [AWS.FileSystemCredentials](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/FileSystemCredentials.html) or the prefix for [AWS.EnvironmentCredentials](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/EnvironmentCredentials.html).
+  2. If no credentials are provided, the default values from AWS CLI configuration will be used.
 * Try to upload the zipped file to the bucket specified by `amazon.bucket`. If it fails because the bucket doesn't exist, try to create the bucket and then try to upload the zipped file again
 * Uploads the ziped files to the bucket on the path `{{ name }}/{{ filename }}` (i.e: `my-application/1.0.0-2016.04.08_13.26.32.zip`)
 * Creates a new version on the Application specified by `applicationName` with VersionLabel `{ version }-{ timestamp }` (i.e: `1.0.0-2016.04.08_13.26.32`)

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "left-pad": "^1.1.1",
     "lodash": "^4.8.2",
     "plexer": "^1.0.1",
-    "through2": "^2.0.1"
+    "through2": "^2.0.1",
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",

--- a/src/aws.js
+++ b/src/aws.js
@@ -61,13 +61,18 @@ export class S3File {
      *
      * @async
      * @method S3File#create
+     * @param  {String} [region]  Region where the bucket is to be created
      * @return {Promise}  Resolved once the action has completed
-     *
+
      * @see [AWS.S3#createBucket]{@link http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#createBucket-property}
      */
-    async create() {
+    async create(region) {
         return await new Promise((resolve, reject) => {
-            this.s3bucket.createBucket((err, result) => {
+            this.s3bucket.createBucket({
+                CreateBucketConfiguration: {
+                   LocationConstraint: region
+                }
+            }, (err, result) => {
                 if (err) reject(err)
                 else resolve(result)
             })

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -189,11 +189,11 @@ export async function deploy(opts, file, s3file, bean) {
  * * versionLabel: version. version + currentTimestamp if timestamp was true
  * * filename: versionLavel + '.zip'
  *
- * If the resulting object amazon property contains accessKeyId and
- * secretAccessKey, both will be added as `AWS.config.credentials`.
+ * If the resulting object amazon property contains credentials,
+   they will be added as `AWS.config.credentials`.
  *
- * If the resulting object amazon property contains signatureVersion, it will
- * be added to `AWS.config`, ese v4 will be used as signatureVersion
+ * If the resulting object amazon property contains a configuration object,
+ * it will be applied to `AWS.config`.
  *
  * @param  {Object} opts
  * @return {Object}
@@ -231,6 +231,10 @@ export function buildOptions(opts) {
     AWS.config.update(Object.assign({
         signatureVersion: 'v4'
     }, options.amazon.config || {}))
+
+    // legacy support for signatureVersion now covered by config parameter
+    if (options.amazon.signatureVersion)
+        AWS.config.signatureVersion = options.amazon.signatureVersion
 
     if (options.amazon.credentials !== undefined) {
         const creds = options.amazon.credentials

--- a/test/test.js
+++ b/test/test.js
@@ -551,7 +551,16 @@ describe('Gulp plugin', () => {
             AWS.config.signatureVersion.should.be.equal('v4')
         })
 
-        it('allows to set a signatureVersion for AWS.config', () => {
+        it('allows to set a signatureVersion for AWS.config (legacy)', () => {
+            buildOptions({
+                amazon: {
+                    signatureVersion: 'v2'
+                }
+            })
+            AWS.config.signatureVersion.should.be.equal('v2')
+        })
+
+        it('allows to supply additional paramters to passed into AWS.config', () => {
             buildOptions({
                 amazon: {
                     config: {


### PR DESCRIPTION
This PR adds a `credentials` field to `options.amazon` which takes an [AWS.Credentials](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Credentials.html) object and assigns it to `AWS.config.credentials`.

I'm aware that gulp-elasticbeanstalk-deploy already supports `accessKeyId` and `secretAccessKey`, however these alone only work for permanent credentials. Adding support for AWS.Credentials should make this module work in pretty much all cases including AssumeRole accounts and federated users.