### PR TITLE
Fix date value in timestamp

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -30,7 +30,7 @@ export function delay(time = 100) {
 export function currentDate() {
     const date = new Date()
     const YYYY = pad(date.getFullYear())
-    const MM = pad(date.getMonth(), 2, 0)
+    const MM = pad(date.getMonth() + 1, 2, 0)
     const DD = pad(date.getDate(), 2, 0)
     const HH = pad(date.getHours(), 2, 0)
     const mm = pad(date.getMinutes(), 2, 0)

--- a/test/test.js
+++ b/test/test.js
@@ -448,8 +448,9 @@ describe('Gulp plugin', () => {
             const valRgx = /^([0-9]{4})\.([0-9]{2})\.([0-9]{2})_([0-9]{2})\.([0-9]{2})\.([0-9]{2})$/
             dateStr.should.match(valRgx)
             const match = valRgx.exec(dateStr)
+            const currentMonth = now.getMonth()+1
             now.getFullYear().should.be.equal(Number(match[1]))
-            now.getMonth().should.be.equal(Number(match[2]))
+            currentMonth.should.be.equal(Number(match[2]))
             now.getDate().should.be.equal(Number(match[3]))
             now.getHours().should.be.equal(Number(match[4]))
             now.getMinutes().should.be.equal(Number(match[5]))


### PR DESCRIPTION
The date.getMonth() returns with a value between 0 and 11 (e.g.: January == 0). To display the correct date, you should add 1 to that.

Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth